### PR TITLE
Encourage good naming of syntax themes

### DIFF
--- a/lib/package-generator-view.coffee
+++ b/lib/package-generator-view.coffee
@@ -25,15 +25,20 @@ class PackageGeneratorView extends View
     @previouslyFocusedElement = $(':focus')
     @message.text("Enter #{mode} path")
     atom.workspaceView.append(this)
-    @setPathText("#{mode}-name")
+    if @mode == 'package'
+      @setPathText("my-package")
+    else
+      @setPathText("my-theme-syntax", [0, 8])
     @miniEditor.focus()
 
-  setPathText: (placeholderName) ->
+  setPathText: (placeholderName, rangeToSelect) ->
     {editor} = @miniEditor
+    rangeToSelect ?= [0, placeholderName.length]
     packagesDirectory = @getPackagesDirectory()
     editor.setText(path.join(packagesDirectory, placeholderName))
     pathLength = editor.getText().length
-    editor.setSelectedBufferRange([[0, pathLength - placeholderName.length], [0, pathLength]])
+    endOfDirectoryIndex = pathLength - placeholderName.length
+    editor.setSelectedBufferRange([[0, endOfDirectoryIndex + rangeToSelect[0]], [0, endOfDirectoryIndex + rangeToSelect[1]]])
 
   detach: ->
     return unless @hasParent()

--- a/spec/package-generator-spec.coffee
+++ b/spec/package-generator-spec.coffee
@@ -12,15 +12,28 @@ describe 'Package Generator', ->
     activationPromise = atom.packages.activatePackage("package-generator")
 
   describe "when package-generator:generate-package is triggered", ->
-    it "displays a miniEditor", ->
+    it "displays a miniEditor with the correct text selected", ->
       atom.workspaceView.trigger("package-generator:generate-package")
 
       waitsForPromise ->
         activationPromise
 
       runs ->
-        packageGeneratorView = atom.workspaceView.find(".package-generator")
-        expect(packageGeneratorView).toExist()
+        packageGeneratorView = atom.workspaceView.find(".package-generator").view()
+        themeName = packageGeneratorView.miniEditor.editor.getSelectedText()
+        expect(themeName).toEqual 'my-package'
+
+  describe "when package-generator:generate-theme is triggered", ->
+    it "displays a miniEditor with correct text selected", ->
+      atom.workspaceView.trigger("package-generator:generate-syntax-theme")
+
+      waitsForPromise ->
+        activationPromise
+
+      runs ->
+        packageGeneratorView = atom.workspaceView.find(".package-generator").view()
+        themeName = packageGeneratorView.miniEditor.editor.getSelectedText()
+        expect(themeName).toEqual 'my-theme'
 
   describe "when core:cancel is triggered", ->
     it "detaches from the DOM and focuses the the previously focused element", ->


### PR DESCRIPTION
There were a number of syntax themes popping up on twitter that were just named something like 'cool-theme'. This pull encourages them to suffix with `-syntax`. Minor, but I would really like to have a naming convention for themes. 

![screen shot 2014-02-27 at 4 13 53 pm](https://f.cloud.github.com/assets/69169/2289775/b82fb35e-a00d-11e3-896d-e27dec9a8b95.png)
