### PR TITLE
Create in dev mode

### DIFF
--- a/lib/package-generator-view.coffee
+++ b/lib/package-generator-view.coffee
@@ -74,7 +74,12 @@ class PackageGeneratorView extends View
     @runCommand(atom.packages.getApmPath(), ['init', "--#{@mode}", "#{packagePath}"], callback)
 
   linkPackage: (packagePath, callback) ->
-    @runCommand(atom.packages.getApmPath(), ['link', "#{packagePath}"], callback)
+    args = ['link']
+    if atom.config.get 'package-generator.createInDevMode'
+      args.push '--dev'
+    args.push packagePath.toString()
+
+    @runCommand(atom.packages.getApmPath(), args, callback)
 
   createPackageFiles: (callback) ->
     packagePath = @getPackagePath()

--- a/lib/package-generator.coffee
+++ b/lib/package-generator.coffee
@@ -1,6 +1,9 @@
 PackageGeneratorView = require './package-generator-view'
 
 module.exports =
+  configDefaults:
+    createInDevMode: false
+
   activate: ->
     @view = new PackageGeneratorView()
 

--- a/spec/package-generator-spec.coffee
+++ b/spec/package-generator-spec.coffee
@@ -125,7 +125,7 @@ describe 'Package Generator', ->
             expect(atom.open.argsForCall[0][0].pathsToOpen[0]).toBe packagePath
 
         it "calls `apm init` and `apm link --dev`", ->
-          atom.config.set 'package-generator.createInDevMode', false
+          atom.config.set 'package-generator.createInDevMode', true
 
           generateOutside ->
             expect(apmExecute.argsForCall[0][0]).toBe atom.packages.getApmPath()


### PR DESCRIPTION
Adds a "createInDevMode" setting, which defaults to true. When checked, packages created outside of `.atom` will be linked in to `.atom/dev/packages` instead of `.atom/packages`, which seems like a sensible place to put a package you're just writing.

See atom/atom#2148.

![screen shot 2014-05-16 at 1 54 38 pm](https://cloud.githubusercontent.com/assets/17565/3000397/3268233e-dd23-11e3-9598-0472d44d50bb.png)
