### PR TITLE
Normalize package path before creating it

### DIFF
--- a/lib/package-generator-view.coffee
+++ b/lib/package-generator-view.coffee
@@ -62,7 +62,7 @@ class PackageGeneratorView extends View
         @close()
 
   getPackagePath: ->
-    packagePath = @miniEditor.getText().trim()
+    packagePath = fs.normalize(@miniEditor.getText().trim())
     packageName = _.dasherize(path.basename(packagePath))
     path.join(path.dirname(packagePath), packageName)
 

--- a/spec/package-generator-spec.coffee
+++ b/spec/package-generator-spec.coffee
@@ -96,6 +96,23 @@ describe 'Package Generator', ->
         expect(apmExecute.mostRecentCall.args[0]).toBe atom.packages.getApmPath()
         expect(apmExecute.mostRecentCall.args[1]).toEqual ['init', '--package', "#{path.join(path.dirname(packagePath), "camel-case-is-for-the-birds")}"]
 
+    it "normalizes the package's path", ->
+      packagePath = path.join("~", "the-package")
+      atom.commands.dispatch(getWorkspaceView(), "package-generator:generate-package")
+
+      waitsForPromise ->
+        activationPromise
+
+      runs ->
+        packageGeneratorView = $(getWorkspaceView()).find(".package-generator").view()
+        packageGeneratorView.miniEditor.setText(packagePath)
+        apmExecute = spyOn(packageGeneratorView, 'runCommand')
+        atom.commands.dispatch(packageGeneratorView.element, "core:confirm")
+
+        expect(apmExecute).toHaveBeenCalled()
+        expect(apmExecute.mostRecentCall.args[0]).toBe atom.packages.getApmPath()
+        expect(apmExecute.mostRecentCall.args[1]).toEqual ['init', '--package', "#{fs.normalize(packagePath)}"]
+
     describe 'when creating a package', ->
       beforeEach ->
         atom.commands.dispatch(getWorkspaceView(), "package-generator:generate-package")


### PR DESCRIPTION
This fixes https://github.com/atom/package-generator/issues/27.

* 25d8e7e adds a spec to demonstrate the problem. Running the specs at this commit [produces one failure](https://travis-ci.org/atom/package-generator/builds/69449862), as expected:

  ```
Running specs...
[584:0703/143458:INFO:renderer_main.cc(212)] Renderer process started
[582:0703/143500:INFO:CONSOLE(56)] "Window load time: 1869ms", source: file:///Users/travis/build/atom/package-generator/atom/Atom.app/Contents/Resources/app.asar/static/index.js (56)
....F.......
Package Generator
  when a package is generated
    it normalizes the package's path
      Expected [ 'init', '--package', '~/the-package' ] to equal [ 'init', '--package', '/Users/travis/the-package' ].
        at [object Object].<anonymous> (/Users/travis/build/atom/package-generator/spec/package-generator-spec.coffee:114:51)
        at _fulfilled (/Users/travis/build/atom/package-generator/atom/Atom.app/Contents/Resources/app.asar/node_modules/q/q.js:794:54)
        at self.promiseDispatch.done (/Users/travis/build/atom/package-generator/atom/Atom.app/Contents/Resources/app.asar/node_modules/q/q.js:823:30)
        at Promise.promise.promiseDispatch (/Users/travis/build/atom/package-generator/atom/Atom.app/Contents/Resources/app.asar/node_modules/q/q.js:756:13)
        at /Users/travis/build/atom/package-generator/atom/Atom.app/Contents/Resources/app.asar/node_modules/q/q.js:564:44
        at flush (/Users/travis/build/atom/package-generator/atom/Atom.app/Contents/Resources/app.asar/node_modules/q/q.js:110:17)
        at process._tickCallback (node.js:357:13)
Finished in 2.126 seconds
12 tests, 46 assertions, 1 failure, 0 skipped
  ```

* cce217d fixes the problem by normalizing the package path after user input. Running the specs at this commit [produces 0 failures](https://travis-ci.org/atom/package-generator/builds/69450998).

cc @kevinsawicki for :eyes: 