### PR TITLE
Support JS package generation

### DIFF
--- a/lib/package-generator-view.coffee
+++ b/lib/package-generator-view.coffee
@@ -34,7 +34,7 @@ class PackageGeneratorView extends View
     @previouslyFocusedElement = $(document.activeElement)
     @panel.show()
     @message.text("Enter #{mode} path")
-    if @mode is 'package'
+    if @isInPackageMode()
       @setPathText("my-package")
     else
       @setPathText("my-theme-syntax", [0, 8])
@@ -79,8 +79,16 @@ class PackageGeneratorView extends View
     else
       true
 
+  getInitOptions: (packagePath) ->
+    options = ["--#{@mode}", packagePath]
+    if @isInPackageMode()
+      [options..., '--syntax', atom.config.get('package-generator.packageSyntax')]
+    else
+      options
+
   initPackage: (packagePath, callback) ->
-    @runCommand(atom.packages.getApmPath(), ['init', "--#{@mode}", "#{packagePath}"], callback)
+    command = ['init', @getInitOptions(packagePath)...]
+    @runCommand(atom.packages.getApmPath(), command, callback)
 
   linkPackage: (packagePath, callback) ->
     args = ['link']
@@ -88,6 +96,9 @@ class PackageGeneratorView extends View
     args.push packagePath.toString()
 
     @runCommand(atom.packages.getApmPath(), args, callback)
+
+  isInPackageMode: ->
+    @mode is 'package'
 
   isStoredInDotAtom: (packagePath) ->
     packagesPath = path.join(atom.getConfigDirPath(), 'packages', path.sep)

--- a/package.json
+++ b/package.json
@@ -28,6 +28,12 @@
       "default": false,
       "type": "boolean",
       "description": "When disabled, generated packages are linked into Atom in both normal mode and dev mode. When enabled, generated packages are linked into Atom only in dev mode."
+    },
+    "packageSyntax": {
+      "default": "coffeescript",
+      "type": "string",
+      "enum": ["coffeescript", "javascript"],
+      "description": "The syntax to generate packages with."
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
       "description": "When disabled, generated packages are linked into Atom in both normal mode and dev mode. When enabled, generated packages are linked into Atom only in dev mode."
     },
     "packageSyntax": {
-      "default": "coffeescript",
+      "default": "javascript",
       "type": "string",
       "enum": ["coffeescript", "javascript"],
       "description": "The syntax to generate packages with."


### PR DESCRIPTION
Addresses https://github.com/atom/package-generator/issues/14

Now that https://github.com/atom/apm/pull/417 has been merged, JS package generation can be done from the UI, so that's what happens here. I ran with the third idea I mentioned in https://github.com/atom/package-generator/issues/14 because it made the most sense to me.

![image](https://cloud.githubusercontent.com/assets/963631/11325989/a4a1cdd0-912a-11e5-96cc-9b52ec7cc6de.png)
