### PR TITLE
Add optional parameters from apm init command

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -6,6 +6,16 @@ module.exports =
       default: false
       type: 'boolean'
       description: 'When disabled, generated packages are linked into Atom in both normal mode and dev mode. When enabled, generated packages are linked into Atom only in dev mode.'
+    packageParams:
+      title: 'Package parameters'
+      default: ''
+      type: 'string'
+      description: 'extra parameters related to apm init command package section'
+    themeParams:
+      title: 'Theme parameters'
+      default: ''
+      type: 'string'
+      description: 'extra parameters related to apm init command theme section'
 
   activate: ->
     @view = new PackageGeneratorView()

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -10,7 +10,7 @@ module.exports =
       title: 'Package parameters'
       default: ''
       type: 'string'
-      description: 'Parameters related to apm init command for packages (```--syntax <javascript-or-coffeescript>\```, ```-c <Path or URL to Textmate bundle>``` or ```--template <Path to template>```)'
+      description: 'Parameters related to apm init command for packages (```--syntax <javascript-or-coffeescript>```, ```-c <Path or URL to Textmate bundle>``` or ```--template <Path to template>```)'
     themeParams:
       title: 'Theme parameters'
       default: ''

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -10,12 +10,12 @@ module.exports =
       title: 'Package parameters'
       default: ''
       type: 'string'
-      description: 'extra parameters related to apm init command package section'
+      description: 'Parameters related to apm init command for packages (```--syntax <javascript-or-coffeescript>\```, ```-c <Path or URL to Textmate bundle>``` or ```--template <Path to template>```)'
     themeParams:
       title: 'Theme parameters'
       default: ''
       type: 'string'
-      description: 'extra parameters related to apm init command theme section'
+      description: 'Parameters related to apm init command for themes (```-c <Path or URL to Textmate bundle>``` or ```--template <Path to template>```)'
 
   activate: ->
     @view = new PackageGeneratorView()

--- a/lib/package-generator-view.coffee
+++ b/lib/package-generator-view.coffee
@@ -80,7 +80,16 @@ class PackageGeneratorView extends View
       true
 
   initPackage: (packagePath, callback) ->
-    @runCommand(atom.packages.getApmPath(), ['init', "--#{@mode}", "#{packagePath}"], callback)
+    args = ['init', "--#{@mode}", "#{packagePath}"]
+    params = @initParameters()
+    args = args.concat params.split(" ") if params.trim()
+    @runCommand(atom.packages.getApmPath(), args, callback)
+
+  initParameters: ->
+    if @mode is 'package'
+      return atom.config.get('package-generator.packageParams')
+    else
+      return atom.config.get('package-generator.themeParams')
 
   linkPackage: (packagePath, callback) ->
     args = ['link']

--- a/lib/package-generator-view.coffee
+++ b/lib/package-generator-view.coffee
@@ -80,12 +80,16 @@ class PackageGeneratorView extends View
       true
 
   initPackage: (packagePath, callback) ->
-    args = ['init', "--#{@mode}", "#{packagePath}"]
-    params = @initParameters()
-    args = args.concat params.split(" ") if params.trim()
+    args = @generateArgumentList(['init', "--#{@mode}", "#{packagePath}"], @getOptionalParameters())
     @runCommand(atom.packages.getApmPath(), args, callback)
 
-  initParameters: ->
+  generateArgumentList: (args, parameters) ->
+    if parameters.trim()
+      return args.concat parameters.split(" ")
+    else
+      return args
+
+  getOptionalParameters: ->
     if @mode is 'package'
       return atom.config.get('package-generator.packageParams')
     else

--- a/spec/package-generator-spec.coffee
+++ b/spec/package-generator-spec.coffee
@@ -137,6 +137,7 @@ describe 'Package Generator', ->
 
         it "calls `apm init` and `apm link`", ->
           atom.config.set 'package-generator.createInDevMode', false
+          atom.config.set 'package-generator.packageParams', ''
 
           generateOutside ->
             expect(apmExecute.argsForCall[0][0]).toBe atom.packages.getApmPath()
@@ -147,12 +148,24 @@ describe 'Package Generator', ->
 
         it "calls `apm init` and `apm link --dev`", ->
           atom.config.set 'package-generator.createInDevMode', true
+          atom.config.set 'package-generator.packageParams', ''
 
           generateOutside ->
             expect(apmExecute.argsForCall[0][0]).toBe atom.packages.getApmPath()
             expect(apmExecute.argsForCall[0][1]).toEqual ['init', '--package', "#{packagePath}"]
             expect(apmExecute.argsForCall[1][0]).toBe atom.packages.getApmPath()
             expect(apmExecute.argsForCall[1][1]).toEqual ['link', '--dev', "#{packagePath}"]
+            expect(atom.open.argsForCall[0][0].pathsToOpen[0]).toBe packagePath
+
+        it "calls `apm init --template /home/test` and `apm link`", ->
+          atom.config.set 'package-generator.createInDevMode', false
+          atom.config.set 'package-generator.packageParams', '--template /home/test'
+
+          generateOutside ->
+            expect(apmExecute.argsForCall[0][0]).toBe atom.packages.getApmPath()
+            expect(apmExecute.argsForCall[0][1]).toEqual ['init', '--package', "#{packagePath}", '--template', '/home/test']
+            expect(apmExecute.argsForCall[1][0]).toBe atom.packages.getApmPath()
+            expect(apmExecute.argsForCall[1][1]).toEqual ['link', "#{packagePath}"]
             expect(atom.open.argsForCall[0][0].pathsToOpen[0]).toBe packagePath
 
       describe "when the package is created inside the packages directory", ->
@@ -183,6 +196,7 @@ describe 'Package Generator', ->
 
       describe "when the theme is created outside of the packages directory", ->
         it "calls `apm init` and `apm link`", ->
+          atom.config.set 'package-generator.themeParams', ''
           packageGeneratorView = $(getWorkspaceView()).find(".package-generator").view()
           expect(packageGeneratorView.hasParent()).toBeTruthy()
           packageGeneratorView.miniEditor.setText(packagePath)
@@ -196,6 +210,25 @@ describe 'Package Generator', ->
           runs ->
             expect(apmExecute.argsForCall[0][0]).toBe atom.packages.getApmPath()
             expect(apmExecute.argsForCall[0][1]).toEqual ['init', '--theme', "#{packagePath}"]
+            expect(apmExecute.argsForCall[1][0]).toBe atom.packages.getApmPath()
+            expect(apmExecute.argsForCall[1][1]).toEqual ['link', "#{packagePath}"]
+            expect(atom.open.argsForCall[0][0].pathsToOpen[0]).toBe packagePath
+
+        it "calls `apm init --template /home/test` and `apm link`", ->
+          atom.config.set 'package-generator.themeParams', '--template /home/test'
+          packageGeneratorView = $(getWorkspaceView()).find(".package-generator").view()
+          expect(packageGeneratorView.hasParent()).toBeTruthy()
+          packageGeneratorView.miniEditor.setText(packagePath)
+          apmExecute = spyOn(packageGeneratorView, 'runCommand').andCallFake (command, args, exit) ->
+            process.nextTick -> exit()
+          atom.commands.dispatch(packageGeneratorView.element, "core:confirm")
+
+          waitsFor ->
+            atom.open.callCount is 1
+
+          runs ->
+            expect(apmExecute.argsForCall[0][0]).toBe atom.packages.getApmPath()
+            expect(apmExecute.argsForCall[0][1]).toEqual ['init', '--theme', "#{packagePath}", "--template", "/home/test"]
             expect(apmExecute.argsForCall[1][0]).toBe atom.packages.getApmPath()
             expect(apmExecute.argsForCall[1][1]).toEqual ['link', "#{packagePath}"]
             expect(atom.open.argsForCall[0][0].pathsToOpen[0]).toBe packagePath


### PR DESCRIPTION
Hi team of atom package-generator. This is my first contribution so I am not sure if i am following the correct protocol, if not so let me know.

The intention of this pull request is to add the optional parameters for package creation that exist in apm to the package-generator. I Though this was something helpful to achieve the end goal of this 2 threads:
- [Design “reference package” for showcasing view frameworks](https://discuss.atom.io/t/design-reference-package-for-showcasing-view-frameworks/24251)
- [Let's choose a view framework for docs, generated packages, etc.](https://github.com/atom/atom/issues/5756)

This changes aim to help in the long run to create packages based in templates created by the community, removing the repetitive few steps of integrating a framework and creating the basic files.

![package manager](https://cloud.githubusercontent.com/assets/3071208/12385583/ff0a50f2-bdbd-11e5-827c-c44c03c958f6.png)
