### PR TITLE
Give packages dir precedence to env var over internal config.

### DIFF
--- a/lib/package-generator-view.coffee
+++ b/lib/package-generator-view.coffee
@@ -77,8 +77,8 @@ class PackageGeneratorView
     path.join(path.dirname(packagePath), packageName)
 
   getPackagesDirectory: ->
-    atom.config.get('core.projectHome') or
-      process.env.ATOM_REPOS_HOME or
+    process.env.ATOM_REPOS_HOME or
+      atom.config.get('core.projectHome') or
       path.join(fs.getHomeDirectory(), 'github')
 
   validPackagePath: ->


### PR DESCRIPTION
### Description of the Change
Existing behaviour has packages being created in the directory given by the Atom core config value `projectHome` if it exists, falling back to the environment variable `ATOM_REPOS_HOME` if it does not. Since the core config has a default value, setting the `ATOM_REPOS_HOME` var has no impact unless the config value is also unset. This defeats the purpose of providing the env var as a way to override the repo dir and is generally contrary to the typical pattern of env vars overriding internal configs.
### Alternate Designs
Drop `ATOM_REPOS_HOME` entirely, allowing project dir override through config only.
### Benefits
People who work on Atom packages will be less confused about how to setup their environments.
### Possible Drawbacks
Package build tooling might break for people who've set a value for `ATOM_REPOS_HOME` that they don't use and have forgotten about.
### Applicable Issues
https://github.com/atom/package-generator/issues/33

cc @thomasjo @danielbayley
