### PR TITLE
Add language package generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,4 @@
 [![Windows Build Status](https://ci.appveyor.com/api/projects/status/7t1i4hdmljhigp9u/branch/master?svg=true)](https://ci.appveyor.com/project/Atom/package-generator/branch/master) [![Dependency Status](https://david-dm.org/atom/package-generator.svg)](https://david-dm.org/atom/package-generator)
 
 
-Generates and opens a new sample package or syntax theme in Atom.
+Generates and opens a new sample package, language, or syntax theme in Atom.

--- a/lib/package-generator-view.js
+++ b/lib/package-generator-view.js
@@ -24,6 +24,7 @@ class PackageGeneratorView {
 
     this.disposables.add(atom.commands.add('atom-workspace', {
       'package-generator:generate-package': () => this.attach('package'),
+      'package-generator:generate-language-package': () => this.attach('language'),
       'package-generator:generate-syntax-theme': () => this.attach('theme')
     }))
 
@@ -47,8 +48,10 @@ class PackageGeneratorView {
     this.previouslyFocusedElement = document.activeElement
     this.panel.show()
     this.message.textContent = `Enter ${this.mode} path`
-    if (this.isInPackageMode()) {
+    if (this.mode === 'package') {
       this.setPathText('my-package')
+    } else if (this.mode === 'language') {
+      this.setPathText('language-my-language', [9, Infinity])
     } else {
       this.setPathText('my-theme-syntax', [0, 8])
     }
@@ -102,7 +105,7 @@ class PackageGeneratorView {
 
   getInitOptions (packagePath) {
     const options = [`--${this.mode}`, packagePath]
-    if (this.isInPackageMode()) {
+    if (this.mode !== 'theme') {
       return [...options, '--syntax', atom.config.get('package-generator.packageSyntax')]
     } else {
       return options
@@ -120,10 +123,6 @@ class PackageGeneratorView {
     args.push(packagePath.toString())
 
     this.runCommand(atom.packages.getApmPath(), args, callback)
-  }
-
-  isInPackageMode () {
-    return this.mode === 'package'
   }
 
   isStoredInDotAtom (packagePath) {

--- a/package.json
+++ b/package.json
@@ -2,11 +2,12 @@
   "name": "package-generator",
   "version": "1.2.0",
   "main": "./lib/main",
-  "description": "Generates and opens a new sample package or syntax theme.",
+  "description": "Generates and opens a new sample package, language, or syntax theme.",
   "license": "MIT",
   "activationCommands": {
     "atom-workspace": [
       "package-generator:generate-package",
+      "package-generator:generate-language-package",
       "package-generator:generate-syntax-theme"
     ]
   },


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Now that the Flight Manual has a grammar tutorial, I think that the built-in package-generator should also give the option to generate a new language package :).

### Alternate Designs

None.

### Benefits

People can easily generate a new language package from within Atom.  It's already supported by apm!

### Possible Drawbacks

None.

### Applicable Issues

Refs atom/flight-manual.atom.io#374